### PR TITLE
(B) PLT-3498: Remove validation for 'sex' attribute in Demographics model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oneroster_client (2.0.1)
+    oneroster_client (2.0.3)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/lib/oneroster_client/models/demographic_type.rb
+++ b/lib/oneroster_client/models/demographic_type.rb
@@ -247,8 +247,8 @@ module OneRosterClient
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      sex_validator = EnumAttributeValidator.new('', ['male', 'female'])
-      return false unless sex_validator.valid?(@sex)
+      # sex_validator = EnumAttributeValidator.new('', ['male', 'female'])
+      # return false unless sex_validator.valid?(@sex)
       return false if @sourced_id.nil?
       return false if @status.nil?
       status_validator = EnumAttributeValidator.new('', ['active', 'tobedeleted'])
@@ -260,10 +260,10 @@ module OneRosterClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sex Object to be assigned
     def sex=(sex)
-      validator = EnumAttributeValidator.new('', ['male', 'female'])
-      unless validator.valid?(sex)
-        fail ArgumentError, "invalid value for \"sex\", must be one of #{validator.allowable_values}."
-      end
+      # validator = EnumAttributeValidator.new('', ['male', 'female'])
+      # unless validator.valid?(sex)
+      #   fail ArgumentError, "invalid value for \"sex\", must be one of #{validator.allowable_values}."
+      # end
       @sex = sex
     end
 

--- a/lib/oneroster_client/models/demographic_type.rb
+++ b/lib/oneroster_client/models/demographic_type.rb
@@ -91,7 +91,7 @@ module OneRosterClient
       {
         :'birth_date' => :'birthDate',
         :'sex' => :'sex',
-        :'american_indian_or_alaska_native' => :'americanIndianOrAlsakaNative',
+        :'american_indian_or_alaska_native' => :'americanIndianOrAlaskaNative',
         :'asian' => :'asian',
         :'black_or_african_american' => :'blackOrAfricanAmerican',
         :'native_hawaiian_or_other_pacific_islander' => :'nativeHawaiianOrOtherPacificIslander',

--- a/lib/oneroster_client/models/demographic_type_all_of.rb
+++ b/lib/oneroster_client/models/demographic_type_all_of.rb
@@ -78,7 +78,7 @@ module OneRosterClient
       {
         :'birth_date' => :'birthDate',
         :'sex' => :'sex',
-        :'american_indian_or_alaska_native' => :'americanIndianOrAlsakaNative',
+        :'american_indian_or_alaska_native' => :'americanIndianOrAlaskaNative',
         :'asian' => :'asian',
         :'black_or_african_american' => :'blackOrAfricanAmerican',
         :'native_hawaiian_or_other_pacific_islander' => :'nativeHawaiianOrOtherPacificIslander',

--- a/lib/oneroster_client/version.rb
+++ b/lib/oneroster_client/version.rb
@@ -10,5 +10,5 @@ Swagger Codegen version: 3.0.34
 =end
 
 module OneRosterClient
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/openapi_original.json
+++ b/openapi_original.json
@@ -6143,7 +6143,7 @@
             "enum" : [ "male", "female" ],
             "type" : "string"
           },
-          "americanIndianOrAlsakaNative" : {
+          "americanIndianOrAlaskaNative" : {
             "description" : "Model Primitive Datatype = Boolean",
             "type" : "boolean"
           },


### PR DESCRIPTION
Not all students have 'male' or 'female' gender specified in the SIS.  This allows us to still pull demographic info for these students when using this OneRoster client.  

Currently, the `powerschool-oneroster-adapter` sets `sex` to `None` if male or female is not selected in PowerSchool.

This allows us to still pull the demographic info for the students with unmarked genders